### PR TITLE
Added `safe_none` as parameter and control decoration

### DIFF
--- a/examples/testing_performance/app.py
+++ b/examples/testing_performance/app.py
@@ -3,16 +3,26 @@ import os
 import pstats
 from random import random
 
-from indicator_management import RawSeriesIndicator, generate_sync
+from indicator_management import (
+    RawSeriesIndicator,
+    generate_sync,
+    multiplication,
+    summation,
+)
 
 
-def main(count: int = 10**6):
+def main(count: int = 10**5, safe_none: bool = True):
     def generate_forever():
         while True:
             yield random()
 
     raw_series = RawSeriesIndicator(raw_values=generate_forever())
-    double_x_plus_1 = raw_series * 2 + 1
+    double_x_plus_1 = summation(
+        multiplication(raw_series, 2, start=1, safe_none=safe_none),
+        1,
+        start=0,
+        safe_none=safe_none,
+    )
 
     generate = generate_sync(i=double_x_plus_1)
     for _ in range(count):
@@ -20,7 +30,11 @@ def main(count: int = 10**6):
 
 
 if __name__ == "__main__":
-    cProfile.run("main()", "temp.perf")
-    p = pstats.Stats("temp.perf")
-    p.strip_dirs().sort_stats("tottime").print_stats(100)
-    os.remove("temp.perf")
+    cProfile.run("main(safe_none=True)", "safe_none_yes.perf")
+    cProfile.run("main(safe_none=False)", "safe_none_no.perf")
+    p_yes = pstats.Stats("safe_none_yes.perf")
+    p_no = pstats.Stats("safe_none_no.perf")
+    p_yes.strip_dirs().sort_stats("tottime").print_stats(20)
+    p_no.strip_dirs().sort_stats("tottime").print_stats(20)
+    os.remove("safe_none_yes.perf")
+    os.remove("safe_none_no.perf")

--- a/src/indicator_management/_types.py
+++ b/src/indicator_management/_types.py
@@ -1,5 +1,20 @@
 from numbers import Number
-from typing import SupportsFloat, TypeVar, Union
+from typing import Any, Callable, Protocol, SupportsFloat, TypeVar, Union
 
 T = TypeVar("T")
 Numeric = Union[Number, SupportsFloat]
+
+S = TypeVar("S")
+R = TypeVar("R")
+
+
+class BoundMethod(Protocol[S, R]):
+    """
+    Represents bound method. Used for typing hints.
+    """
+
+    __func__: Callable[..., R]
+    __self__: S
+
+    def __call__(self, *args: Any, **kwargs: Any) -> R:
+        ...


### PR DESCRIPTION
# Brief Description

Added `safe_none` as `OperationIndicator`'s initialization and control decoration.

# Changes

- Added `safe_none` in `OperationIndicator.__init__`
- Now `OperationIndicator.__init__` is conditionally decorated by `safe_none`
- Changed content of `default_if_none_in_pre_requisites`
- Added `BoundMethod` for typing hints
