### PR TITLE
Feature: Optimize `ConstantIndicator`

### DIFF
--- a/src/indicator_management/indicators/base.py
+++ b/src/indicator_management/indicators/base.py
@@ -272,10 +272,13 @@ class ConstantIndicator(AbstractIndicator[T]):
     """
 
     def __init__(self, constant: T) -> None:
-        super().__init__(default_value=constant)
+        super().__init__(default_value=constant, history_length=0)
 
     def update_single(self) -> None:
-        self.set_value(self._default_value)
+        pass
+
+    def __call__(self, index: int) -> Optional[T]:
+        return self._default_value
 
 
 N_or_AIN = Union[Numeric, AbstractIndicator[Numeric]]

--- a/src/indicator_management/indicators/base.py
+++ b/src/indicator_management/indicators/base.py
@@ -292,7 +292,7 @@ class OperationIndicator(AbstractIndicator[T]):
     def __init__(
         self,
         *pre_requisites: AbstractIndicator,
-        operation: Callable[..., T],
+        operation: Callable[..., Optional[T]],
         safe_none: bool = True,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
# Brief Description

I've optimized `ConstantIndicator` and fixed some typing.

# Changes

- Optimized `ConstantIndicator` by changing `update_single` and `__call__` (From now `ConstantIndicator` will always yield `_default_value` regardless of `index`)
- Fixed typing of `OperationIndicator.__init__`