### PR TITLE
Fix: Import structure

### DIFF
--- a/examples/dynamic_plotting/app.py
+++ b/examples/dynamic_plotting/app.py
@@ -15,13 +15,13 @@ from typing import Generator, Union
 import matplotlib.animation as pltanim
 import matplotlib.pyplot as plt
 
-from indicator_management import (
+from indicator_management import generate_sync
+from indicator_management.indicators import (
     AbstractIndicator,
     ExponentialMovingAverage,
     RawSeriesIndicator,
     SimpleHistoricalStats,
     SimpleMovingAverage,
-    generate_sync,
     maximum,
     minimum,
 )

--- a/examples/simple_arithmetic_operation/app.py
+++ b/examples/simple_arithmetic_operation/app.py
@@ -11,7 +11,8 @@ import random
 
 import matplotlib.pyplot as plt
 
-from indicator_management import AbstractIndicator, RawSeriesIndicator, generate_sync
+from indicator_management import generate_sync
+from indicator_management.indicators import AbstractIndicator, RawSeriesIndicator
 
 
 def main():

--- a/examples/testing_performance/app.py
+++ b/examples/testing_performance/app.py
@@ -3,9 +3,9 @@ import os
 import pstats
 from random import random
 
-from indicator_management import (
+from indicator_management import generate_sync
+from indicator_management.indicators import (
     RawSeriesIndicator,
-    generate_sync,
     multiplication,
     summation,
 )

--- a/src/indicator_management/__init__.py
+++ b/src/indicator_management/__init__.py
@@ -1,4 +1,4 @@
+from . import indicators
 from .errors import *
 from .graph import toposort
-from .indicators import *
 from .orchestration import generate_async, generate_sync

--- a/src/indicator_management/__init__.py
+++ b/src/indicator_management/__init__.py
@@ -1,4 +1,3 @@
-from . import indicators
-from .errors import *
+from . import errors, indicators
 from .graph import toposort
 from .orchestration import generate_async, generate_sync

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -5,7 +5,8 @@ from math import sin as raw_sin
 from math import tan as raw_tan
 from typing import Iterable
 
-from src.indicator_management import (
+from src.indicator_management import generate_sync
+from src.indicator_management.indicators import (
     AgingIndicator,
     ExponentialMovingAverage,
     RawSeriesIndicator,
@@ -15,7 +16,6 @@ from src.indicator_management import (
     and_keyword,
     booleanize,
     cos,
-    generate_sync,
     greater,
     greater_or_equal,
     less,


### PR DESCRIPTION
# Brief Description

I've fixed import structure. I've wrapped `indicators` and `errors` in main `__init__.py`.

# Changes

- Wrapped `indicators` and `errors` in main `__init__.py`.
- Fixed tests and example application codes regarding import structure changes.