### PR TITLE
Feature: Less context switching in `generate_async`

### DIFF
--- a/examples/testing_async_performance/app.py
+++ b/examples/testing_async_performance/app.py
@@ -1,0 +1,37 @@
+import asyncio
+import cProfile
+import os
+import pstats
+from random import random
+
+from indicator_management import generate_async
+from indicator_management.indicators import (
+    AsyncRawSeriesIndicator,
+    multiplication,
+    summation,
+)
+
+
+async def main(count: int = 10**5, safe_none: bool = False):
+    async def generate_forever():
+        while True:
+            yield random()
+
+    raw_series = AsyncRawSeriesIndicator(raw_values=generate_forever())
+    double_x_plus_1 = summation(
+        multiplication(raw_series, 2, start=1, safe_none=safe_none),
+        1,
+        start=0,
+        safe_none=safe_none,
+    )
+
+    generate = generate_async(i=double_x_plus_1)
+    for _ in range(count):
+        await generate.__anext__()
+
+
+if __name__ == "__main__":
+    cProfile.run("asyncio.run(main())", "async_test.perf")
+    p = pstats.Stats("async_test.perf")
+    p.strip_dirs().sort_stats("tottime").print_stats(20)
+    os.remove("async_test.perf")

--- a/src/indicator_management/indicators/base.py
+++ b/src/indicator_management/indicators/base.py
@@ -68,6 +68,7 @@ class AbstractIndicator(Generic[T]):
     """
 
     global_nonce: int = 0
+    __is_sync__: bool = True
 
     def __init__(
         self,
@@ -283,6 +284,8 @@ class AsyncRawSeriesIndicator(AbstractIndicator[T]):
     Represents an indicator which is updated by
     asynchronous raw value stream.
     """
+
+    __is_sync__: bool = False
 
     def __init__(
         self,

--- a/src/indicator_management/indicators/base.py
+++ b/src/indicator_management/indicators/base.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 from .._types import BoundMethod, ComparisonFunc, Numeric, T
+from ..errors import IndicatorManagementError
 from ..utils import (
     chained_keyword_and,
     chained_keyword_or,
@@ -228,13 +229,23 @@ class AbstractIndicator(Generic[T]):
         """
         Asynchronously update current indicator.
         """
-        self.update_single()
+        if self.__is_sync__:
+            raise IndicatorManagementError(
+                "update_single_async should not be called from sync indicator"
+            )
+        else:
+            raise NotImplementedError
 
     def update_single(self) -> None:
         """
         Calculate and update new indicator value based on given `sources`.
         """
-        raise NotImplementedError
+        if self.__is_sync__:
+            raise NotImplementedError
+        else:
+            raise IndicatorManagementError(
+                "update_single should not be called from async indicator"
+            )
 
 
 AI = TypeVar("AI", bound=AbstractIndicator)
@@ -268,12 +279,6 @@ class RawSeriesIndicator(AbstractIndicator[T]):
     def __init__(self, *, raw_values: Iterable[Optional[T]], **kwargs) -> None:
         super().__init__(default_value=None, **kwargs)
         self._raw_values: Iterator[Optional[T]] = iter(raw_values)
-
-    async def update_single_async(self) -> None:
-        try:
-            self.update_single()
-        except StopIteration as exc:
-            raise StopAsyncIteration(*exc.args).with_traceback(exc.__traceback__)
 
     def update_single(self) -> None:
         self.set_value(next(self._raw_values))

--- a/src/indicator_management/orchestration.py
+++ b/src/indicator_management/orchestration.py
@@ -29,29 +29,48 @@ async def generate_async(
     **indicators: AbstractIndicator,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """
-    Asynchronously generate all indicators by flow.
+    Asynchronously generate all indicators by flow,
+    but reduce context switching as possible.
     """
     extended_toposorted: list[list[AbstractIndicator]] = toposort(*indicators.values())
+    extended_classified: list[
+        tuple[tuple[AbstractIndicator, ...], tuple[AbstractIndicator, ...]]
+    ] = []
+    for batched_indicators in extended_toposorted:
+        indicators_sync = tuple(
+            indicator for indicator in batched_indicators if indicator.__is_sync__
+        )
+        indicators_async = tuple(
+            indicator for indicator in batched_indicators if not indicator.__is_sync__
+        )
+        extended_classified.append((indicators_sync, indicators_async))
+
     try:
         while True:
-            for batched_indicators in extended_toposorted:
-                done, pending = await asyncio.wait(
-                    [
-                        asyncio.create_task(indicator.update_single_async())
-                        for indicator in batched_indicators
-                    ],
-                    return_when=asyncio.FIRST_EXCEPTION,
-                )
-                while done:
-                    task = done.pop()
-                    exc = task.exception()
-                    if exc:
-                        for running_task in pending:
-                            running_task.cancel()
-                        raise exc
-            yield {
-                indicator_name: indicator(0)
-                for indicator_name, indicator in indicators.items()
-            }
-    except StopAsyncIteration:
+            for sync_indicators, async_indicators in extended_classified:
+
+                for indicator in sync_indicators:
+                    indicator.update_single()
+
+                if async_indicators:
+                    async_done, async_pending = await asyncio.wait(
+                        [
+                            asyncio.create_task(indicator.update_single_async())
+                            for indicator in async_indicators
+                        ],
+                        return_when=asyncio.FIRST_EXCEPTION,
+                    )
+                    while async_done:
+                        task = async_done.pop()
+                        exc = task.exception()
+                        if exc:
+                            for running_task in async_pending:
+                                running_task.cancel()
+                            raise exc
+
+                yield {
+                    indicator_name: indicator(0)
+                    for indicator_name, indicator in indicators.items()
+                }
+    except (StopIteration, StopAsyncIteration):
         pass

--- a/src/indicator_management/orchestration.py
+++ b/src/indicator_management/orchestration.py
@@ -68,9 +68,9 @@ async def generate_async(
                                 running_task.cancel()
                             raise exc
 
-                yield {
-                    indicator_name: indicator(0)
-                    for indicator_name, indicator in indicators.items()
-                }
+            yield {
+                indicator_name: indicator(0)
+                for indicator_name, indicator in indicators.items()
+            }
     except (StopIteration, StopAsyncIteration):
         pass

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,28 @@
+import random
+import unittest
+
+from src.indicator_management import generate_async
+from src.indicator_management.indicators import AsyncRawSeriesIndicator
+
+
+async def random_forever():
+    while True:
+        yield random.random()
+
+
+class AsyncOrchestrationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_simple(self):
+        x1 = AsyncRawSeriesIndicator(raw_values=random_forever())
+        x2 = AsyncRawSeriesIndicator(raw_values=random_forever())
+        add = x1 + x2
+        async_generator = generate_async(x1=x1, x2=x2, add=add)
+
+        iteration = 0
+        while iteration < 10:
+            obj = await async_generator.__anext__()
+            self.assertAlmostEqual(obj["x1"] + obj["x2"], obj["add"])
+            iteration += 1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Brief Description

I've reduced the context switching in `generate_async`.

# Changes

- Now `generate_async` does not create coroutines for synchronous indicators.
- Added related examples and tests
