### PR TITLE
Feature: Lazy indicator(pre-requisite) registration

### DIFF
--- a/src/indicator_management/indicators/base.py
+++ b/src/indicator_management/indicators/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from functools import wraps
+from itertools import zip_longest
 from numbers import Number
 from typing import (
     Any,
@@ -225,6 +226,18 @@ class AbstractIndicator(Generic[T]):
 
     # =================================================================================
     # Update APIs
+
+    def lazily_update_pre_requisites(
+        self, *pre_requisites: Optional[AbstractIndicator]
+    ) -> None:
+        """
+        Lazily update pre-requisites. This method should be called very carefully,
+        because the update order might be changed or cyclic dependencies may occur.
+        """
+        self.pre_requisites = tuple(
+            new_prq or old_prq
+            for old_prq, new_prq in zip_longest(self.pre_requisites, pre_requisites)
+        )
 
     async def update_single_async(self) -> None:
         """

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,13 +1,26 @@
 import random
 import unittest
 
-from src.indicator_management import generate_async
-from src.indicator_management.indicators import AsyncRawSeriesIndicator
+from src.indicator_management import generate_async, generate_sync
+from src.indicator_management.errors import CannotResolveIndicatorGraph
+from src.indicator_management.indicators import (
+    AbstractIndicator,
+    AsyncRawSeriesIndicator,
+)
 
 
 async def random_forever():
     while True:
         yield random.random()
+
+
+class SyncOrchestrationTest(unittest.TestCase):
+    def test_cyclic_dependencies(self):
+        x1 = AbstractIndicator()
+        x2 = AbstractIndicator(x1)
+        x1.lazily_update_pre_requisites(x2)
+        with self.assertRaises(CannotResolveIndicatorGraph):
+            list(generate_sync(x1=x1, x2=x2))
 
 
 class AsyncOrchestrationTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
# Brief Description

I've added lazy pre-requisite indicator registration method for future features.

# Changes

- Added `lazily_update_pre_requisites` method in `AbstractIndicator`
- Added tests for detecting cyclic dependencies
